### PR TITLE
update to regex for deprecation warnings

### DIFF
--- a/lib/HTML/HeadParser/Liberal.pm
+++ b/lib/HTML/HeadParser/Liberal.pm
@@ -9,7 +9,7 @@ our $VERSION = "0.02";
 
 BEGIN {
     my $code = "sub " . B::Deparse->new->coderef2text(\&HTML::HeadParser::start);
-    $code =~ s/(if \(\$\$attr{'name'}\) {)/$1 \$attr->{name} =~ s\/:\/_\/g;/gsm;
+    $code =~ s/(if \(\$\$attr\{'name'}\) \{)/$1 \$attr->{name} =~ s\/:\/_\/g;/gsm;
 
     no warnings 'redefine';
     *HTML::HeadParser::start = eval $code;


### PR DESCRIPTION
update regex to be compliant with now deprecated unescaped left brace in regex (as of perl 5.22) so logs dont get filled with annoying warnings about it.
